### PR TITLE
more spring cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+### Prepare
+
+```
+opam pin add arbitrary-graph https://github.com/yomimono/arbitrary-network.git
+opam pin add mirage-nat https://github.com/yomimono/ocaml-nat.git
+```
+
+(optional)
+```
+opam pin add lwt 'https://github.com/mirage/lwt.git#tracing
+```
+
+### Compile
+
+```
+mirage configure
+make
+```

--- a/config.ml
+++ b/config.ml
@@ -4,16 +4,16 @@ let main = foreign "Simple_nat.Main" (console @-> network @-> network @-> job)
 
 let primary_netif = (netif "0")
 let secondary_netif = (netif "1") (* netif actually needs an integer, shoved
-into a string, which maps to a device ID number assigned by Xen, to do anything 
+into a string, which maps to a device ID number assigned by Xen, to do anything
 helpful when xen is the target.  Stuff that can't be turned into an int
 is silently dropped in that case and we just get the first Xen network iface. *)
 
 let tracing = mprof_trace ~size:100000 ()
 
-let () = 
+let () =
   add_to_opam_packages ["ocaml-nat";"tcpip";"mirage-profile"];
   add_to_ocamlfind_libraries ["mirage_nat";
                               "tcpip.ethif";"tcpip.ipv4";"mirage-profile"];
   register "simple_nat" ~tracing [
-    main $ default_console $ primary_netif $ secondary_netif 
+    main $ default_console $ primary_netif $ secondary_netif
   ]

--- a/config.ml
+++ b/config.ml
@@ -11,9 +11,9 @@ is silently dropped in that case and we just get the first Xen network iface. *)
 let tracing = mprof_trace ~size:100000 ()
 
 let () =
-  add_to_opam_packages ["ocaml-nat";"tcpip";"mirage-profile"];
-  add_to_ocamlfind_libraries ["mirage_nat";
+  add_to_opam_packages ["mirage-nat";"tcpip";"mirage-profile"];
+  add_to_ocamlfind_libraries ["mirage-nat";
                               "tcpip.ethif";"tcpip.ipv4";"mirage-profile"];
-  register "simple_nat" ~tracing [
+  register "simple-nat" ~tracing [
     main $ default_console $ primary_netif $ secondary_netif
   ]

--- a/simple_nat.ml
+++ b/simple_nat.ml
@@ -21,7 +21,7 @@ module Main (C: CONSOLE) (PRI: NETWORK) (SEC: NETWORK) = struct
      to rewrite at least ip headers, spit them out the other interface *)
 
   let table () =
-    let open Lookup in
+    let open Nat_lookup in
     (* TODO: rewrite as a bind *)
     match insert (empty ()) 6 (Ipaddr.of_string_exn "10.0.0.2", 80)
             (Ipaddr.of_string_exn "192.168.3.1", 52966)(external_ip, 9999) Active with


### PR DESCRIPTION
Sorry to remove all your spaces! :p 

about `mirage-nat` / `ocaml-nat`: I find it a bit confusing, that the repo, the opam package and the ocamlfind package have a different name. Pick one (I'd prefer `mirage-nat` are it's mainly useful in the context of mirage applications but feel free to choose the name that you prefer).
